### PR TITLE
Make the substitution more explicit

### DIFF
--- a/mega/utils.py
+++ b/mega/utils.py
@@ -7,7 +7,7 @@ from Crypto.Cipher import AES
 
 
 def a32_to_str(a):
-    return struct.pack('>%dI' % len(a), *a)
+    return struct.pack('>{}I'.format(len(a)), *a)
 
 
 def aes_cbc_encrypt(data, key):


### PR DESCRIPTION
Different way of substituting the length of the string in format string as the %-formatting is called the "old %-formatting" in the documentation, be it for python: 
- 2.7 https://docs.python.org/2.7/library/string.html?highlight=string#module-string
or
- 3.6 https://docs.python.org/3.6/library/string.html?highlight=string#module-string