### PR TITLE
Comment big-endian format, the unpacking operator, encryptor creation and encryption call

### DIFF
--- a/mega/utils.py
+++ b/mega/utils.py
@@ -14,6 +14,7 @@ def a32_to_str(a):
 
 def aes_cbc_encrypt(data, key):
     encryptor = AES.new(key, AES.MODE_CBC, '\0' * 16)
+    # choice of CBC mode is justified on https://mega.nz/doc 12.10 "A chunk MAC is computed as follows (this is essentially CBC-MAC, which was chosen instead of the more efficient OCB over intellectual property concerns)"
     # the last argument, the initiatlisation vector is optional http://pythonhosted.org/pycrypto/Crypto.Cipher.AES-module.html#new
     return encryptor.encrypt(data)
     # length data must be a multiple of 16 http://pythonhosted.org/pycrypto/Crypto.Cipher.blockalgo.BlockAlgo-class.html#encrypt

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -14,7 +14,9 @@ def a32_to_str(a):
 
 def aes_cbc_encrypt(data, key):
     encryptor = AES.new(key, AES.MODE_CBC, '\0' * 16)
+    # the last argument, the initiatlisation vector is optional http://pythonhosted.org/pycrypto/Crypto.Cipher.AES-module.html#new
     return encryptor.encrypt(data)
+    # length data must be a multiple of 16 http://pythonhosted.org/pycrypto/Crypto.Cipher.blockalgo.BlockAlgo-class.html#encrypt
 
 
 def aes_cbc_encrypt_a32(data, key):

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -25,7 +25,7 @@ def aes_cbc_encrypt_a32(data, key):
 
 
 def str_to_a32(b):
-    if len(b) % 4:  # Add padding, we need a string with a length multiple of 4
+    if len(b) % 4:  # Add padding, we need a string with a length multiple of 4 because the size of an unsigned integer as indicated in the call of the unpack method below is 4 bytes https://docs.python.org/3.6/library/struct.html#format-characters
         b += '\0' * (4 - len(b) % 4)
     return struct.unpack('>%dI' % (len(b) / 4), b)
 

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -8,6 +8,7 @@ from Crypto.Cipher import AES
 
 def a32_to_str(a):
     return struct.pack('>%dI' % len(a), *a)
+# https://docs.python.org/2/tutorial/controlflow.html#unpacking-argument-lists just to explain the use of '*' in front of 'a'
 
 
 def aes_cbc_encrypt(data, key):

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -32,7 +32,7 @@ def str_to_a32(b):
 
 def mpi2int(s):
     return int(binascii.hexlify(s[2:]), 16)
-# returns the string s, truncated of its 2 first caracters as an integer
+# returns the string s, truncated of its 2 first caracters as an integer https://docs.python.org/3.6/library/functions.html?highlight=int#int
 
 
 def aes_cbc_decrypt(data, key):

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -8,6 +8,7 @@ from Crypto.Cipher import AES
 
 def a32_to_str(a):
     return struct.pack('>%dI' % len(a), *a)
+# > , my guess is that choosing the big-endian and not letting it be native is aiming at making the code independent of the platform, in other words independent of the endianness of the platform: to be checked with @juanriaza https://docs.python.org/3.6/library/struct.html?highlight=struct#byte-order-size-and-alignment
 # https://docs.python.org/2/tutorial/controlflow.html#unpacking-argument-lists just to explain the use of '*' in front of 'a'
 
 

--- a/mega/utils.py
+++ b/mega/utils.py
@@ -32,6 +32,7 @@ def str_to_a32(b):
 
 def mpi2int(s):
     return int(binascii.hexlify(s[2:]), 16)
+# returns the string s, truncated of its 2 first caracters as an integer
 
 
 def aes_cbc_decrypt(data, key):


### PR DESCRIPTION
1. I had to refresh the notion of endianness and found following video helpful https://www.youtube.com/watch?v=MEyV7moej-k 
I guess the idea here is to have the code independent of the platform it is run on, right @juanriaza ?

2. I struggled to understand the unpacking operator '*' until I found following video https://www.youtube.com/watch?v=YWY4BZi_o28. Cool python feature.

3. Is the package pycrypto the right one for AES import? Few comments added from there. https://pypi.python.org/pypi/pycrypto "PyCrypto is written and tested using Python version 2.1 through 3.3. Python 1.5.2 is not supported."
Good simple use of pycrypto is demonstrated here https://www.youtube.com/watch?v=fqjdXMu4ZAQ
